### PR TITLE
Fix provide impl for `Location` information

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -184,15 +184,11 @@ fn impl_struct(input: Struct) -> TokenStream {
     let from_impl = input.from_field().map(|from_field| {
         let span = from_field.attrs.from.unwrap().span;
         let backtrace_field = input.distinct_backtrace_field();
+        let location_field = input.distinct_location_field();
         let from = unoptional_type(from_field.ty);
-        let track_caller = input.location_field().map(|_| quote!(#[track_caller]));
+        let track_caller = location_field.as_ref().map(|_| quote!(#[track_caller]));
         let source_var = Ident::new("source", span);
-        let body = from_initializer(
-            from_field,
-            backtrace_field,
-            &source_var,
-            input.location_field(),
-        );
+        let body = from_initializer(from_field, backtrace_field, &source_var, location_field);
         let from_function = quote! {
             #track_caller
             fn from(#source_var: #from) -> Self {
@@ -474,7 +470,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         let from_field = variant.from_field()?;
         let span = from_field.attrs.from.unwrap().span;
         let backtrace_field = variant.distinct_backtrace_field();
-        let location_field = variant.location_field();
+        let location_field = variant.distinct_location_field();
         let variant = &variant.ident;
         let from = unoptional_type(from_field.ty);
         let source_var = Ident::new("source", span);

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -287,7 +287,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         None
     };
 
-    let provide_method = if input.has_backtrace() {
+    let provide_method = if input.has_backtrace() || input.has_location() {
         let request = quote!(request);
         let arms = input.variants.iter().map(|variant| {
             let ident = &variant.ident;

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -42,6 +42,12 @@ impl Enum<'_> {
             .any(|variant| variant.backtrace_field().is_some())
     }
 
+    pub(crate) fn has_location(&self) -> bool {
+        self.variants
+            .iter()
+            .any(|variant| variant.location_field().is_some())
+    }
+
     pub(crate) fn has_display(&self) -> bool {
         self.attrs.display.is_some()
             || self.attrs.transparent.is_some()

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -25,7 +25,12 @@ impl Struct<'_> {
 
     pub(crate) fn distinct_backtrace_field(&self) -> Option<&Field> {
         let backtrace_field = self.backtrace_field()?;
-        distinct_backtrace_field(backtrace_field, self.from_field())
+        field_if_distinct_from(backtrace_field, self.from_field())
+    }
+
+    pub(crate) fn distinct_location_field(&self) -> Option<&Field> {
+        let location_field = self.location_field()?;
+        field_if_distinct_from(location_field, self.from_field())
     }
 }
 
@@ -82,7 +87,12 @@ impl Variant<'_> {
 
     pub(crate) fn distinct_backtrace_field(&self) -> Option<&Field> {
         let backtrace_field = self.backtrace_field()?;
-        distinct_backtrace_field(backtrace_field, self.from_field())
+        field_if_distinct_from(backtrace_field, self.from_field())
+    }
+
+    pub(crate) fn distinct_location_field(&self) -> Option<&Field> {
+        let location_field = self.location_field()?;
+        field_if_distinct_from(location_field, self.from_field())
     }
 }
 
@@ -159,16 +169,14 @@ fn location_field<'a, 'b>(fields: &'a [Field<'b>]) -> Option<&'a Field<'b>> {
 }
 
 // The #[backtrace] field, if it is not the same as the #[from] field.
-fn distinct_backtrace_field<'a, 'b>(
-    backtrace_field: &'a Field<'b>,
-    from_field: Option<&Field>,
+fn field_if_distinct_from<'a, 'b>(
+    input_field: &'a Field<'b>,
+    check_against: Option<&Field>,
 ) -> Option<&'a Field<'b>> {
-    if from_field.map_or(false, |from_field| {
-        from_field.member == backtrace_field.member
-    }) {
+    if check_against.map_or(false, |from_field| from_field.member == input_field.member) {
         None
     } else {
-        Some(backtrace_field)
+        Some(input_field)
     }
 }
 


### PR DESCRIPTION
I tried using your thiserror pr to track `Location` information and i noticed that the `Error::provide` impl wasn't being properly generated when only using `#[location]` and not `#[backtrace]`.

Additionally, i noticed that the `Location::caller()` information was generated even when the `#[location]` is on a `#[from]` field meant to forward the information (like with `#[backtrace]`). 